### PR TITLE
Catch errors when decoding packet body

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,11 @@ function decode () {
         }
         reader.read(msg.length, function (err, body) {
           if(err) return cb(err)
-          decodeBody(body, msg)
+          try {
+            decodeBody(body, msg)
+          } catch(e) {
+            return cb(e)
+          }
           cb(null, msg)
         })
       })


### PR DESCRIPTION
Without this, an application may crash when it receives a packet with invalid JSON.