### PR TITLE
tidy, modernize JS, modernize test toolkit

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+pnpm-lock.yaml
+package-lock.json

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+semi: false
+singleQuote: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - '0.10'
-  - '0.12'

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Dominic Tarr
+Copyright (c) 2022 Andre 'Staltz' Medeiros
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
-shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const GOODBYE = 'GOODBYE'
 function encodePair(msg) {
   let head = Buffer.alloc(9)
   let flags = 0
-  let value = msg.value !== undefined ? msg.value : msg.end
+  let body = msg.value !== undefined ? msg.value : msg.end
 
   // final packet
   if (typeof msg === 'string' && msg === GOODBYE) {
@@ -18,14 +18,14 @@ function encodePair(msg) {
     return [head, null]
   }
 
-  if (typeof value === 'string') {
+  if (typeof body === 'string') {
     flags = STRING
-    value = Buffer.from(value, 'utf-8')
-  } else if (Buffer.isBuffer(value)) {
+    body = Buffer.from(body, 'utf-8')
+  } else if (Buffer.isBuffer(body)) {
     flags = BUFFER
   } else {
     flags = OBJECT
-    value = Buffer.from(JSON.stringify(value), 'utf-8')
+    body = Buffer.from(JSON.stringify(body), 'utf-8')
   }
 
   // does this frame represent a msg, a req, or a stream?
@@ -36,10 +36,10 @@ function encodePair(msg) {
 
   head[0] = flags
 
-  head.writeUInt32BE(value.length, 1)
+  head.writeUInt32BE(body.length, 1)
   head.writeInt32BE(msg.req || 0, 5)
 
-  return [head, value]
+  return [head, body]
 }
 
 function decodeHead(bytes) {
@@ -71,10 +71,10 @@ function decodeBody(bytes, msg) {
 }
 
 function encode() {
-  return Through(function pscEncodeHeadAndValue(d) {
-    const [head, value] = encodePair(d)
+  return Through(function pscEncodeHeadAndBody(data) {
+    const [head, body] = encodePair(data)
     this.queue(head)
-    if (value !== null) this.queue(value)
+    if (body !== null) this.queue(body)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
   "name": "packet-stream-codec",
-  "description": "binary codec for packet-stream",
+  "description": "Binary codec for packet-stream",
   "version": "1.1.3",
-  "homepage": "https://github.com/dominictarr/packet-stream-codec",
+  "homepage": "https://github.com/ssbc/packet-stream-codec",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dominictarr/packet-stream-codec.git"
+    "url": "git://github.com/ssbc/packet-stream-codec.git"
   },
   "dependencies": {
-    "pull-reader": "^1.2.4",
-    "pull-through": "^1.0.17"
+    "pull-reader": "^1.3.1",
+    "pull-through": "^1.0.18"
   },
   "devDependencies": {
-    "pull-stream": "^3.2.3",
-    "tape": "~4.0.0",
-    "pull-randomly-split": "~1.0.4"
+    "pull-randomly-split": "~1.0.4",
+    "pull-stream": "^3.6.14",
+    "tap-spec": "^5.0.0",
+    "tape": "~5.5.0"
   },
   "engines": {
-    "node": ">=5.10.0"
+    "node": ">=12"
   },
   "scripts": {
     "prepublish": "npm test",
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape test/*.js | tap-spec"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/ssbc/packet-stream-codec.git"
   },
+  "files": [
+    "*.js"
+  ],
   "dependencies": {
     "pull-reader": "^1.3.1",
     "pull-through": "^1.0.18"


### PR DESCRIPTION
Context: I found a way of debugging all muxrpc calls, and it involves adding some small amount of code to this library.

Before that, I wanted to modernize this library with:

- ES6 JavaScript (thus Node.js at least 8.0)
- GitHub CI tests
- Update tape
- Apply prettier with same rules as ssb-db2
- Name the functions to avoid anonymous functions (they make stacktraces harder to debug)